### PR TITLE
Search from dtrt-indent-hook-mapping-list using derived-mode-parent.

### DIFF
--- a/dtrt-indent-diag.el
+++ b/dtrt-indent-diag.el
@@ -31,8 +31,7 @@
   (interactive)
   (require 'benchmark)
   (let ((language-and-variable
-         (cdr (assoc major-mode
-                     dtrt-indent-hook-mapping-list))))
+         (cdr (dtrt-indent--search-hook-mapping major-mode))))
 
     (with-output-to-temp-buffer "*dtrt-indent-debug*"
     (if (null language-and-variable)

--- a/dtrt-indent-test.el
+++ b/dtrt-indent-test.el
@@ -34,8 +34,8 @@
     (setq dtrt-indent-min-relevant-lines 3)
     (insert (cdr (assoc :buffer-contents args)))
     (let* ((language-and-variable
-            (cdr (assoc (cdr (assoc :mode args))
-                        dtrt-indent-hook-mapping-list)))
+            (cdr (dtrt-indent--search-hook-mapping
+                  (cdr (assoc :mode args)))))
            (result
             (dtrt-indent--analyze
              (dtrt-indent--calc-histogram
@@ -158,6 +158,20 @@ aa /*foo
         softspace-line")
    (:mode . c-mode)
    (:expected-tab-setting . undecided)
+   (:expected-offset . 8)))
+
+(define-derived-mode derived-c-mode c-mode "Derived-C"
+  "Derived-C for Test")
+
+(dtrt-indent-functional-test
+ '((:buffer-contents . "\
+	tabbed-line
+        softspace-line
+        softspace-line
+        softspace-line
+        softspace-line")
+   (:mode . derived-c-mode)
+   (:expected-tab-setting . soft)
    (:expected-offset . 8)))
 
 (when nil ;; disabled

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -681,6 +681,12 @@ rejected: too few distinct matching offsets (%d required)"
            (t
             nil)))))
 
+(defun dtrt-indent--search-hook-mapping(mode)
+  "Search hook-mapping for MODE or its derived-mode-parent."
+  (if mode
+      (or (assoc mode dtrt-indent-hook-mapping-list)
+          (dtrt-indent--search-hook-mapping (get mode 'derived-mode-parent)))))
+
 (defun dtrt-indent--analyze (histogram-and-total-lines)
   "Analyze the histogram.
 
@@ -803,12 +809,8 @@ merged with offset %s (%.2f%% deviation, limit %.2f%%)"
 
 (defun dtrt-indent-try-set-offset ()
   "Try adjusting the current buffer's indentation offset."
-  (let ((language-and-variable
-         (cdr (assoc major-mode
-                     dtrt-indent-hook-mapping-list))))
-
+  (let ((language-and-variable (cdr (dtrt-indent--search-hook-mapping major-mode))))
     (when language-and-variable
-
       (let* ((result
               (dtrt-indent--analyze
                (dtrt-indent--calc-histogram
@@ -939,8 +941,7 @@ Note: killed buffer-local value for %s, restoring to default %d"
 
 Disable dtrt-indent if offset explicitly set."
   (cond
-   ((eql (nth 2 (assoc major-mode
-                       dtrt-indent-hook-mapping-list))
+   ((eql (nth 2 (dtrt-indent--search-hook-mapping major-mode))
          (ad-get-arg 0))
     (setq dtrt-indent-explicit-offset t))
    ((eql 'indent-tab-mode


### PR DESCRIPTION
Maybe, using derived-mode-parent reduces maintenance costs.

eg)
html-mode's derived-mode-parent is sgml-mode.
scss-mode's derived-mode-parent is css-mode.
