### PR TITLE
independently adapt indent-offset and indent-tabs-mode

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -902,7 +902,9 @@ Indentation offset set with file variable; not adjusted")
               best-indent-offset)))
          (t
           (when (>= dtrt-indent-verbosity 2)
-            (message "Note: %s not adjusted" indent-offset-variable))
+            (message "Note: %s not adjusted%s" indent-offset-variable
+                     (if (and rejected (>= dtrt-indent-verbosity 3))
+                         (format ": %s" rejected) "")))
           nil))))))
 
 (defun dtrt-indent-find-file-hook ()

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -226,7 +226,9 @@ transparently."
                 ("'"                     0   "'"        nil "\\.")
                 ("[<][<]\\\\?\\([^ \t]+\\)"   1   "^\\1"     nil)
                 ("("                     0   ")"        t)
-                ("\\["                   0   "\\]"      t)))
+                ("\\["                   0   "\\]"      t))
+
+    (default    ("\""                    0   "\""       nil "\\\\.")))
 
   "A list of syntax tables for supported languages.
 
@@ -274,7 +276,8 @@ quote, for example.")
     (ada-mode        ada           ada-indent)           ; Ada
     (sh-mode         shell         sh-basic-offset)      ; Shell Script
     (css-mode        css           css-indent-offset)    ; CSS
-    (pascal-mode     pascal        pascal-indent-level)) ; Pascal
+    (pascal-mode     pascal        pascal-indent-level)  ; Pascal
+    (default         default       standard-indent))     ; default fallback
    "A mapping from hook variables to language types.")
 
 ;;-----------------------------------------------------------------
@@ -707,7 +710,8 @@ rejected: too few distinct matching offsets (%d required)"
   "Search hook-mapping for MODE or its derived-mode-parent."
   (if mode
       (or (assoc mode dtrt-indent-hook-mapping-list)
-          (dtrt-indent--search-hook-mapping (get mode 'derived-mode-parent)))))
+          (dtrt-indent--search-hook-mapping (get mode 'derived-mode-parent))
+          (assoc 'default dtrt-indent-hook-mapping-list))))
 
 (defun dtrt-indent--analyze (histogram-and-total-lines)
   "Analyze the histogram.


### PR DESCRIPTION
Hi,

I suggest three modular changes that are rather self-explanatory.

The motivation to allow for separate adaption of indent-offset and indent-tabs-mode is the following:
If indent-offset is not changed for any reason, indent-tabs-mode could be change anyway, couldn't it?

To also support "unsupported" major modes, I suggest to introduce a "default" fallback, which simply adapts
standard-indent.

Please decide on the general usefulness of the contributions.

Best, Robert