### PR TITLE
Do not change anything when analyze is rejected

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -820,6 +820,7 @@ merged with offset %s (%.2f%% deviation, limit %.2f%%)"
                        dtrt-indent-min-quality)))))
 
         (cond
+         (rejected)
          ((or (= 0 hard-tab-percentage)
               (>= (/ soft-tab-percentage
                      hard-tab-percentage)


### PR DESCRIPTION
When you open an empty file, dtrt-indent shouldn't touch any settings.
This patch prevents dtrt-indent from forcing indent-tabs-mode to nil
when opening an empty file.

Signed-off-by: Sylvain Chouleur <sylvain.chouleur@gmail.com>