### PR TITLE
Set evil-shift-width when evil-mode is enabled

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -871,7 +871,20 @@ merged with offset %s (%.2f%% deviation, limit %.2f%%)"
              (best-indent-offset
               (nth 0 best-guess))
              (indent-offset-variable
-              (nth 1 language-and-variable)))
+              (nth 1 language-and-variable))
+             (indent-offset-variables
+              (cons
+               indent-offset-variable
+               (remove nil
+                       (mapcar
+                        (lambda (x)
+                          (let ((mode (car x))
+                                (variable (cadr x)))
+                            (when (symbol-value mode) variable)))
+                        dtrt-indent-hook-generic-mapping-list))))
+             (indent-offset-names
+              (mapconcat (lambda (x) (format "%s" x))
+                         indent-offset-variables ", ")))
 
         ; update indent-offset-variable?
         (cond

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -329,6 +329,22 @@ quote, for example.")
     (pascal-mode     pascal        pascal-indent-level)  ; Pascal
     (default         default       standard-indent))     ; default fallback
    "A mapping from hook variables to language types.")
+
+(defvar dtrt-indent-hook-generic-mapping-list
+;;   Key variable    Value variable
+  '((evil-mode       evil-shift-width))  ; evil
+  "A mapping from hook variables to indentation variables.
+For each true key variable, its value variable is set to the same
+indentation offset as the variable in `dtrt-indent-hook-mapping-list'
+(e.g., `c-basic-offset').  Every pair in the list is processed.  To
+disable processing of any one pair, remove the pair from the list.
+Processing the list obeys `dtrt-indent-require-confirmation-flag'.
+
+The key can be any variable.  This list is used for cases such as when
+a minor-mode defines a variable to control its own indentation
+functionality (e.g. `evil-mode' using `evil-shift-width'), so the
+value variable must updated in addition to the syntax indentation
+variable.")
 
 ;;-----------------------------------------------------------------
 ;; Customization Definitions:

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -899,7 +899,7 @@ Indentation offset set with file variable; not adjusted")
             (when (or (not dtrt-indent-require-confirmation-flag)
                       (yes-or-no-p
                        (format "Do you want to adjust %s to %s for buffer %s? "
-                               indent-offset-variable
+                               indent-offset-names
                                best-indent-offset
                                (buffer-name))))
               (setq dtrt-indent-original-indent
@@ -909,20 +909,21 @@ Indentation offset set with file variable; not adjusted")
               (when (>= dtrt-indent-verbosity 1)
                 (let ((offset-info
                        (format "%s adjusted to %s%s"
-                               indent-offset-variable
+                               indent-offset-names
                                best-indent-offset
                                (if (>= dtrt-indent-verbosity 2)
                                    (format " (%.0f%%%% confidence)"
                                            (* 100 confidence))
                                  ""))))
                   (message (concat "Note: " offset-info))))
-              (set (make-local-variable indent-offset-variable)
-                   best-indent-offset)
+              (dolist (x indent-offset-variables)
+                (set (make-local-variable x)
+                     best-indent-offset))
               (setq dtrt-indent-mode-line-info "[dtrt-indent] ")
               best-indent-offset)))
          (t
           (when (>= dtrt-indent-verbosity 2)
-            (message "Note: %s not adjusted%s" indent-offset-variable
+            (message "Note: %s not adjusted%s" indent-offset-variables
                      (if (and rejected (>= dtrt-indent-verbosity 3))
                          (format ": %s" rejected) "")))
           nil))


### PR DESCRIPTION
This variable is buffer-local when set, and controls the offset used by evil-mode's shift commands, > and <. Since shift-width should match indentation, dtrt-indent should update it when updating the mode's
indent-offset-variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jscheid/dtrt-indent/23)
<!-- Reviewable:end -->
