### PR TITLE
Fix handling of Erlang binary literals.

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -250,12 +250,14 @@ adjusted transparently."
     ;; Thus it is best to ignore the code inside these block
     ;; constructs when determining the indent offset.
     (erlang     ("\""                    0   "\""       nil "\\.")
-                ("[<][<]\""              0   "\"[>][>]" nil)
+                ;; next pattern avoids error on git merge conflict lines
+                ("[<][<][<]"             0   "$"        nil)
+                ("[<][<]"                0   "[>][>]"   nil)
                 ("%"                     0   "$"        nil)
                 ("{"                     0   "}"        t)
-		("\\["                   0   "\\]"      t)
+                ("\\["                   0   "\\]"      t)
                 ("("                     0   ")"        t)
-		("\\b\\(begin\\|case\\|fun\\|if\\|receive\\|try\\)\\b"
+                ("\\b\\(begin\\|case\\|fun\\|if\\|receive\\|try\\)\\b"
                                          0   "\\bend\\b" t))
 
     (css        ("\""                    0   "\""       nil "\\.")


### PR DESCRIPTION
Delimiters are '<<' and '>>', not '<<"' and '">>'.

This fixes a bug in my original Erlang patterns that would cause parsing to fail on binaries such as `<<"example", $1, $2, $3>>` (which is equivalent to `<<"example123">>`).

Also replace some tabs with spaces for consistency with the rest of dtrt-indent.el.