### PR TITLE
Fixes for Erlang indentation detection

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -254,11 +254,12 @@ adjusted transparently."
                 ("[<][<][<]"             0   "$"        nil)
                 ("[<][<]"                0   "[>][>]"   nil)
                 ("%"                     0   "$"        nil)
+                ("^-"                    0   "\\."      nil)
                 ("{"                     0   "}"        t)
                 ("\\["                   0   "\\]"      t)
                 ("("                     0   ")"        t)
-                ("\\b\\(begin\\|case\\|fun\\|if\\|receive\\|try\\)\\b"
-                                         0   "\\bend\\b" t))
+                ("\\_<\\(?:begin\\|case\\|fun\\|if\\|receive\\|try\\)\\_>"
+                                         0   "\\_<end\\_>" t))
 
     (css        ("\""                    0   "\""       nil "\\.")
                 ("'"                     0   "'"        nil "\\.")


### PR DESCRIPTION
This commit has two pull requests. The first changes the `dtrt-indent--for-each-indentation` function to do its searches case-sensitively by setting `case-fold-search` to nil. I'm not sure that this is the best place to make this fix, but it "works for me."

The second makes some changes to the `erlang` entry in the `dtrt-indent-language-syntax-table` to be more careful about spuriously detecting Erlang keywords embedded in variable names and other contexts.

The second pull request also changes the skip-regexp for Erlang strings from `"\\." ` to `"\\\\."`. The intention is to skip an escaped `"` or other character inside the string. To do that, we want to skip a literal `\` followed by any one character, so the regular expression is `\\.`. Then, since we have to represent the regular expression as a string, we have to quote those backslashes, making `"\\\\."`. I'm going into so much detail because I noticed that commit 6910fe53165651ad11aa589f94aaa2c625bb11ed made the opposite transformation, which I think was a mistake. To quote the [elisp documentation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Regexp-Special.html#index-g_t_0040samp_007b_005c_007d-in-regexp-3748):

     Note that `\' also has special meaning in the read syntax of Lisp
     strings (*note String Type::), and must be quoted with `\'.  For
     example, the regular expression that matches the `\' character is
     `\\'.  To write a Lisp string that contains the characters `\\',
     Lisp syntax requires you to quote each `\' with another `\'.
     Therefore, the read syntax for a regular expression matching `\'
     is `"\\\\"'.