### PR TITLE
Fix skipping of escaped characters within strings.

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -193,8 +193,8 @@ adjusted transparently."
   :global t :group 'dtrt-indent)
 
 (defvar dtrt-indent-language-syntax-table
-  '((c/c++/java ("\""                    0   "\""       nil "\\.")
-                ("'"                     0   "'"        nil "\\.")
+  '((c/c++/java ("\""                    0   "\""       nil "\\\\.")
+                ("'"                     0   "'"        nil "\\\\.")
                 ("/\\*"                  0   "\\*/"     nil)
                 ("//"                    0   "$"        nil)
                 ("("                     0   ")"        t)
@@ -202,36 +202,36 @@ adjusted transparently."
 
     ;; Same as c/c++/java but ignore function call arguments, to cope with
     ;; modules defined entirely within a function call, e.g. AMD style
-    (javascript ("\""                    0   "\""       nil "\\.")
-                ("'"                     0   "'"        nil "\\.")
+    (javascript ("\""                    0   "\""       nil "\\\\.")
+                ("'"                     0   "'"        nil "\\\\.")
                 ("/\\*"                  0   "\\*/"     nil)
                 ("//"                    0   "$"        nil)
                 ("/\\(.*\\)"             1   "\\1/"     nil)
                 ("\\["                   0   "\\]"      t))
 
-    (perl       ("\""                    0   "\""       nil "\\.")
-                ("'"                     0   "'"        nil "\\.")
-                ("/"                     0   "/"        nil "\\.")
+    (perl       ("\""                    0   "\""       nil "\\\\.")
+                ("'"                     0   "'"        nil "\\\\.")
+                ("/"                     0   "/"        nil "\\\\.")
                 ("#"                     0   "$"        nil)
                 ("("                     0   ")"        t)
                 ("\\["                   0   "\\]"      t))
 
-    (lua        ("\""                    0   "\""       nil "\\.")
-                ("'"                     0   "'"        nil "\\.")
+    (lua        ("\""                    0   "\""       nil "\\\\.")
+                ("'"                     0   "'"        nil "\\\\.")
                 ("--"                    0   "$"        nil)
                 ("("                     0   ")"        t)
                 ("\\[\\(=+\\)\\["        1   "\\]\\1\\]"     nil)
                 ("{"                     0   "}"        t))
 
-    (ruby       ("\""                    0   "\""       nil "\\.")
-                ("'"                     0   "'"        nil "\\.")
-                ("/"                     0   "/"        nil "\\.")
+    (ruby       ("\""                    0   "\""       nil "\\\\.")
+                ("'"                     0   "'"        nil "\\\\.")
+                ("/"                     0   "/"        nil "\\\\.")
                 ("#"                     0   "$"        nil)
                 ("("                     0   ")"        t)
                 ("\\["                   0   "\\]"      t)
                 ("{"                     0   "}"        t))
 
-    (ada        ("\""                    0   "\""       nil "\\.")
+    (ada        ("\""                    0   "\""       nil "\\\\.")
                 ("--"                    0   "$"        nil)
                 ("("                     0   ")"        t)
                 ("\\["                   0   "\\]"      t)
@@ -249,7 +249,7 @@ adjusted transparently."
     ;;
     ;; Thus it is best to ignore the code inside these block
     ;; constructs when determining the indent offset.
-    (erlang     ("\""                    0   "\""       nil "\\.")
+    (erlang     ("\""                    0   "\""       nil "\\\\.")
                 ;; next pattern avoids error on git merge conflict lines
                 ("[<][<][<]"             0   "$"        nil)
                 ("[<][<]"                0   "[>][>]"   nil)
@@ -260,16 +260,16 @@ adjusted transparently."
                 ("\\b\\(begin\\|case\\|fun\\|if\\|receive\\|try\\)\\b"
                                          0   "\\bend\\b" t))
 
-    (css        ("\""                    0   "\""       nil "\\.")
-                ("'"                     0   "'"        nil "\\.")
+    (css        ("\""                    0   "\""       nil "\\\\.")
+                ("'"                     0   "'"        nil "\\\\.")
                 ("/\\*"                  0   "\\*/"   nil))
 
     (sgml       ("[<]!\\[(CDATA|IGNORE|RCDATA)\\["
                                          0   "\\]\\][>]"     nil)
                 ("[<]!--"                0   "[^-]--[>]"  nil))
 
-    (shell      ("\""                    0   "\""       nil "\\.")
-                ("'"                     0   "'"        nil "\\.")
+    (shell      ("\""                    0   "\""       nil "\\\\.")
+                ("'"                     0   "'"        nil "\\\\.")
                 ("[<][<]\\\\?\\([^ \t]+\\)"   1   "^\\1"     nil)
                 ("("                     0   ")"        t)
                 ("\\["                   0   "\\]"      t))


### PR DESCRIPTION
Change the skip-regexp for strings in all languages from `"\\."` to `"\\\\."`.  The intention of the skip-regexp in these cases is to prevent dtrt-indent from incorrectly parsing an escaped quote
character inside a string as the end of the string.  To that end, it needs to skip a literal `\` followed by the character being escaped, so the regular expression is `\\.`.  Since this regular expression then has to be represented as an emacs string, those backslashes have to be escaped again, making `"\\\\."`.  To quote the elisp documentation[1]:

    Note that `\' also has special meaning in the read syntax of Lisp
    strings (*note String Type::), and must be quoted with `\'.  For
    example, the regular expression that matches the `\' character is
    `\\'.  To write a Lisp string that contains the characters `\\',
    Lisp syntax requires you to quote each `\' with another `\'.
    Therefore, the read syntax for a regular expression matching `\'
    is `"\\\\"'.

[1] https://www.gnu.org/software/emacs/manual/html_node/elisp/Regexp-Special.html#index-g_t_0040samp_007b_005c_007d-in-regexp-3748