### PR TITLE
Use case-sensitive search when applying language syntax table.

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -656,21 +656,22 @@ from the process.  For each line not excluded, FUNC is called
 with USER-DATA as its argument and with point on the first
 non-whitespace character of the line."
   (save-excursion
-    (goto-char (point-min))
-    (while (and (re-search-forward "^[ \t]*" nil t)
-                (funcall func user-data)
-                (progn
-                  (dtrt-indent--skip-to-end-of-match
-                   nil
-                   nil
-                   (cdr
-                    (assoc language
-                           dtrt-indent-language-syntax-table))
-                   nil)
-                  (beginning-of-line)
-                  (let ((here (point)))
-                    (forward-line)
-                    (not (eq here (point)))))))))
+    (let ((case-fold-search nil))
+      (goto-char (point-min))
+      (while (and (re-search-forward "^[ \t]*" nil t)
+                  (funcall func user-data)
+                  (progn
+                    (dtrt-indent--skip-to-end-of-match
+                     nil
+                     nil
+                     (cdr
+                      (assoc language
+                             dtrt-indent-language-syntax-table))
+                     nil)
+                    (beginning-of-line)
+                    (let ((here (point)))
+                      (forward-line)
+                      (not (eq here (point))))))))))
 
 (defun dtrt-indent--calc-histogram (language)
   "Calculate an indendation histogram.


### PR DESCRIPTION
By default the emacs search functions are case-insensitive.  However the `dtrt-indent-language-syntax-table` contains some keywords that should be searched in case-sensitive manner.  This commit sets `case-fold-search` to nil in `dtrt-indent--for-each-indentation` to make those searches case-sensitive.

This affected the Erlang indent-guessing.  In Erlang, `fun` is a keyword that introduces a lambda function that is terminated with `end`.  When dtrt-indent did a case-insensitive search, however, a variable named `Fun` fooled it into thinking that a function was being defined, and the rest of the file was not analyzed because there was no matching `end`.

This change will also affect the SGML CDATA pattern.

The whitespace changes make this commit look like a bigger change than it actually is. Ignoring the whitespace diffs, the real change is:
```diff
diff --git a/dtrt-indent.el b/dtrt-indent.el
index f4945df..348fb46 100644
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -656,6 +656,7 @@ from the process.  For each line not excluded, FUNC is called
 with USER-DATA as its argument and with point on the first
 non-whitespace character of the line."
   (save-excursion
+    (let ((case-fold-search nil))
       (goto-char (point-min))
       (while (and (re-search-forward "^[ \t]*" nil t)
                   (funcall func user-data)
@@ -670,7 +671,7 @@ non-whitespace character of the line."
                     (beginning-of-line)
                     (let ((here (point)))
                       (forward-line)
-                    (not (eq here (point)))))))))
+                    (not (eq here (point))))))))))

 (defun dtrt-indent--calc-histogram (language)
   "Calculate an indendation histogram.
```