### PR TITLE
Remove syntax table

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -269,12 +269,6 @@ adjusted transparently."
                                          0   "\\]\\][>]"     nil)
                 ("[<]!--"                0   "[^-]--[>]"  nil))
 
-    (shell      ("\""                    0   "\""       nil "\\\\.")
-                ("'"                     0   "'"        nil "\\\\.")
-                ("[<][<]\\\\?\\([^ \t]+\\)"   1   "^\\1"     nil)
-                ("("                     0   ")"        t)
-                ("\\["                   0   "\\]"      t))
-
     (default    ("\""                    0   "\""       nil "\\\\.")))
 
   "A list of syntax tables for supported languages.
@@ -329,7 +323,7 @@ quote, for example.")
     (pascal-mode     pascal        pascal-indent-level)  ; Pascal
 
     ;; Modes that use SMIE if available
-    (sh-mode         shell         sh-basic-offset)      ; Shell Script
+    (sh-mode         default       sh-basic-offset)      ; Shell Script
     (ruby-mode       ruby          ruby-indent-level)    ; Ruby
     (css-mode        css           css-indent-offset)    ; CSS
 


### PR DESCRIPTION
As we discussed on #35. I actually don't know how to run the tests for this repo (haven't written a lot of elisp), so I can't tell if they're passing. Let me know if there are issues.

By the way, I have a couple more commits for your consideration [here](https://github.com/tummychow/dtrt-indent/commits/update-mode-declaration). I didn't want to piggyback them into this change because they're not really related (also, they're breaking), but let me know if you're willing to accept these in another PR.