### PR TITLE
Mention vim-sleuth in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 An Emacs minor mode that guesses the indentation offset originally used for creating source code files and transparently adjusts the corresponding settings in Emacs, making it more convenient to edit foreign files.
 
 See `dtrt-indent.el` for full documentation, including installation instructions.
+
+# Related work
+[vim-sleuth](https://github.com/tpope/vim-sleuth) provides similar functionally to some extent.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ An Emacs minor mode that guesses the indentation offset originally used for crea
 See `dtrt-indent.el` for full documentation, including installation instructions.
 
 # Related work
-[vim-sleuth](https://github.com/tpope/vim-sleuth) provides similar functionally to some extent.
+
+[vim-sleuth](https://github.com/tpope/vim-sleuth) provides similar functionality for Vim.


### PR DESCRIPTION
It took me ages to find this plugin, despite the fact that I have been searching for a `vim-sleuth` replacement ever since I moved from vim (and I know a few others with similar experiences).
Mentioning `vim-sleuth` here would save countless hours for such people.