### PR TITLE
Add enh-ruby-mode to dtrt-indent-hook-mapping-list

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -340,6 +340,7 @@ quote, for example.")
     ;; Modes that use SMIE if available
     (sh-mode         default       sh-basic-offset)      ; Shell Script
     (ruby-mode       ruby          ruby-indent-level)    ; Ruby
+    (enh-ruby-mode   ruby          enh-ruby-indent-level); Ruby
     (css-mode        css           css-indent-offset)    ; CSS
 
     (default         default       standard-indent))     ; default fallback


### PR DESCRIPTION
Adds support for [enh-ruby-mode](https://github.com/zenspider/enhanced-ruby-mode).

We could probably do the same for `crystal-mode`, since it is heavily ruby inspired:

```diff
+  (crystal-mode ruby crystal-indent-level)
```

What do you think?