### PR TITLE
Several improvements in file local variable usage

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -114,7 +114,7 @@
 ;;
 ;; Configuration settings used at this stage:
 ;; `dtrt-indent-max-merge-deviation'
-;
+;;
 ;; Final Evaluation
 ;;
 ;; Finally, dtrt-indent looks at the highest probability of all
@@ -153,6 +153,22 @@
 ;;
 ;; - Files for which `dtrt-indent-explicit-offset' is true; this can be
 ;; - used in `.dir-locals.el' files, for example.
+;;
+;; Overriding analysis on a file or directory basis
+;;
+;; Some local variables, as set in a file comment, .dir-locals.el,
+;; .dir-locals-2.el or using `dir-locals-set-class-variables'
+;; can be used to override dtrt-indent behavior.
+;;
+;; If the local variable `dtrt-indent-force-offset' is set, this will override
+;; the offset found from analysis.  This will not disable any other processing
+;; such as setting related variables.
+;;
+;; This differs from specifying particular variables e.g. c-basic-offset,
+;; or `dtrt-indent-explicit-offset' which disable setting any related variables.
+;;
+;; If the local variable `indent-tabs-mode' is set, this will be used
+;; for the value of indent-tabs-mode instead of the value determined from analysis.
 ;;
 ;; Limitations:
 ;;
@@ -591,6 +607,9 @@ using more than 8 spaces per indentation level are very rare."
 (make-variable-buffer-local
  'dtrt-indent-explicit-tab-mode)
 
+(defvar dtrt-indent-force-offset)
+(make-variable-buffer-local 'dtrt-indent-force-offset)
+
 (defun dtrt-indent--replace-in-string (haystack
                                         needle-regexp
                                         replacement)
@@ -904,7 +923,8 @@ merged with offset %s (%.2f%% deviation, limit %.2f%%)"
              (indent-tabs-mode-setting
               (cdr (assoc :indent-tabs-mode-setting result)))
              (best-indent-offset
-              (nth 0 best-guess))
+              (or dtrt-indent-force-offset
+                  (nth 0 best-guess)))
              (indent-offset-variable
               (nth 1 language-and-variable))
              (indent-offset-variables
@@ -945,9 +965,12 @@ Indentation offset set with file variable; not adjusted")
                      indent-offset-variables))
               (when (>= dtrt-indent-verbosity 1)
                 (let ((offset-info
-                       (format "%s adjusted to %s%s"
+                       (format "%s adjusted to %s%s%s"
                                indent-offset-names
                                best-indent-offset
+                               (if dtrt-indent-force-offset
+                                   " [forced]"
+                                 "")
                                (if (>= dtrt-indent-verbosity 2)
                                    (format " (%.0f%%%% confidence)"
                                            (* 100 confidence))

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -915,8 +915,9 @@ merged with offset %s (%.2f%% deviation, limit %.2f%%)"
                         (lambda (x)
                           (let ((mode (car x))
                                 (variable (cadr x)))
-                            (when (and (boundp mode)
-                                       (symbol-value mode))
+                            (when (or (and (boundp mode)
+                                           (symbol-value mode))
+                                      (derived-mode-p mode))
                               variable)))
                         dtrt-indent-hook-generic-mapping-list))))
              (indent-offset-names

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -991,23 +991,25 @@ Indentation offset set with file variable; not adjusted")
         (cond
          ((and change-indent-tabs-mode
                (not (eq indent-tabs-mode indent-tabs-mode-setting)))
-          (when (>= dtrt-indent-verbosity 1)
-            (let ((tabs-mode-info
-                   (when (and change-indent-tabs-mode
-                              (not (eql indent-tabs-mode-setting
-                                        indent-tabs-mode)))
-                     (format "indent-tabs-mode adjusted to %s"
-                             indent-tabs-mode-setting))))
-              (message (concat "Note: " tabs-mode-info))))
-          ; backup indent-tabs-mode setting
-          (setq dtrt-indent-original-indent
-                (cons
-                 (let ((x 'indent-tabs-mode))
-                   (list x (symbol-value x) (local-variable-p x)))
-                 dtrt-indent-original-indent))
-          ; actually adapt indent-tabs-mode
-          (set (make-local-variable 'indent-tabs-mode)
-               indent-tabs-mode-setting))
+          (if dtrt-indent-explicit-tab-mode
+              (message "File variable indent-tabs-mode used; no adjustment done");
+            (when (>= dtrt-indent-verbosity 1)
+              (let ((tabs-mode-info
+                     (when (and change-indent-tabs-mode
+                                (not (eql indent-tabs-mode-setting
+                                          indent-tabs-mode)))
+                       (format "indent-tabs-mode adjusted to %s"
+                               indent-tabs-mode-setting))))
+                (message (concat "Note: " tabs-mode-info))))
+                                        ; backup indent-tabs-mode setting
+            (setq dtrt-indent-original-indent
+                  (cons
+                   (let ((x 'indent-tabs-mode))
+                     (list x (symbol-value x) (local-variable-p x)))
+                   dtrt-indent-original-indent))
+                                        ; actually adapt indent-tabs-mode
+            (set (make-local-variable 'indent-tabs-mode)
+                 indent-tabs-mode-setting)))
          (t
           (when (>= dtrt-indent-verbosity 2)
             (message "Note: indent-tabs-mode not adjusted"))

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -194,13 +194,18 @@ adjusted transparently."
   :lighter " dtrt-indent"
   :group 'dtrt-indent
   (if dtrt-indent-mode
-      (if (and (featurep 'smie) (not (eq smie-grammar 'unset)))
-          (progn
-            (when (null smie-config--buffer-local) (smie-config-guess))
-            (when dtrt-indent-run-after-smie
-              (dtrt-indent-try-set-offset)))
-        (dtrt-indent-try-set-offset))
+      (add-hook 'hack-local-variables-hook #'dtrt-indent-post-local-variable-setup t t)
+    (remove-hook 'hack-local-variables-hook #'dtrt-indent-post-local-variable-setup t)
     (dtrt-indent-undo)))
+
+(defun dtrt-indent-post-local-variable-setup ()
+  "Processing to be done after local variables have been processed"
+  (if (and (featurep 'smie) (not (eq smie-grammar 'unset)))
+      (progn
+        (when (null smie-config--buffer-local) (smie-config-guess))
+        (when dtrt-indent-run-after-smie
+          (dtrt-indent-try-set-offset)))
+    (dtrt-indent-try-set-offset)))
 
 ;;;###autoload
 (define-globalized-minor-mode dtrt-indent-global-mode dtrt-indent-mode


### PR DESCRIPTION
The commits first to last:
* make sure file local variables are handled properly by performing the core processing after these variables have been processed, instead of before. 
* Add ability to set related variables when any mode derived from a particular major mode is in effect
* add new variable dtrt-indent-force-offset, which can be used to force the offset to be a particular value without affecting any of the other processing.  This is intended to be used as a file local variable. 
* Fixed the handling of file local indent-tabs-mode setting so that it overrides dtrt-indent's analysis, as per documentation. 