### PR TITLE
Use rust-indent-offset for rust-mode

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -343,6 +343,7 @@ quote, for example.")
     (ruby-mode       ruby          ruby-indent-level)    ; Ruby
     (enh-ruby-mode   ruby          enh-ruby-indent-level); Ruby
     (css-mode        css           css-indent-offset)    ; CSS
+    (rust-mode       default       rust-indent-offset)   ; Rust
 
     (default         default       standard-indent))     ; default fallback
    "A mapping from hook variables to language types.")


### PR DESCRIPTION
rust-mode has its own tab offset, which needs to be set for tabs to be
set correctly. The syntax table is left as default for now, although
this should probably change as well.