### PR TITLE
Add crystal-mode, rustic-mode & scala-mode support

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -342,8 +342,11 @@ quote, for example.")
     (sh-mode         default       sh-basic-offset)      ; Shell Script
     (ruby-mode       ruby          ruby-indent-level)    ; Ruby
     (enh-ruby-mode   ruby          enh-ruby-indent-level); Ruby
+    (crystal-mode    ruby          crystal-indent-level) ; Crystal (Ruby)
     (css-mode        css           css-indent-offset)    ; CSS
     (rust-mode       default       rust-indent-offset)   ; Rust
+    (rustic-mode     default       rustic-indent-offset) ; Rust
+    (scala-mode      c/c++/java    scala-indent:step)    ; Scala
 
     (default         default       standard-indent))     ; default fallback
    "A mapping from hook variables to language types.")

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -344,8 +344,8 @@ quote, for example.")
     (enh-ruby-mode   ruby          enh-ruby-indent-level); Ruby
     (crystal-mode    ruby          crystal-indent-level) ; Crystal (Ruby)
     (css-mode        css           css-indent-offset)    ; CSS
-    (rust-mode       default       rust-indent-offset)   ; Rust
-    (rustic-mode     default       rustic-indent-offset) ; Rust
+    (rust-mode       c/c++/java    rust-indent-offset)   ; Rust
+    (rustic-mode     c/c++/java    rustic-indent-offset) ; Rust
     (scala-mode      c/c++/java    scala-indent:step)    ; Scala
 
     (default         default       standard-indent))     ; default fallback


### PR DESCRIPTION
As mentioned in #48, adds support for [crystal-mode](https://github.com/crystal-lang-tools/emacs-crystal-mode), [rustic-mode](https://github.com/brotzeit/rustic) and [scala-mode](https://github.com/hvesalai/emacs-scala-mode).

Although, should rust-mode and rustic-mode use the `c/c++/java` syntax table? Rust is very similar.