### PR TITLE
Allow change of tab-setting if offset was rejected

### DIFF
--- a/dtrt-indent-test.el
+++ b/dtrt-indent-test.el
@@ -176,6 +176,12 @@ aa /*foo
    (:expected-tab-setting . soft)
    (:expected-offset . 8)))
 
+(dtrt-indent-functional-test
+ '((:buffer-contents . "")
+   (:mode . c-mode)
+   (:expected-tab-setting . undecided)
+   (:expected-offset . nil)))
+
 (when nil ;; disabled
   (with-output-to-temp-buffer "*dtrt-indent-test-results*"
     (dtrt-indent-bulk-test

--- a/dtrt-indent-test.el
+++ b/dtrt-indent-test.el
@@ -20,7 +20,7 @@
 ;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
 ;; Floor, Boston, MA 02110-1301 USA
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (require 'dtrt-indent)
 
@@ -62,17 +62,17 @@
             (cdr (assoc :expected-tab-setting args))))
       (cond
        ((eq expected-tab-setting 'hard)
-        (assert (eq change-indent-tabs-mode t))
-        (assert (eq indent-tabs-mode-setting t)))
+        (cl-assert (eq change-indent-tabs-mode t))
+        (cl-assert (eq indent-tabs-mode-setting t)))
        ((eq expected-tab-setting 'soft)
-        (assert (eq change-indent-tabs-mode t))
-        (assert (eq indent-tabs-mode-setting nil)))
+        (cl-assert (eq change-indent-tabs-mode t))
+        (cl-assert (eq indent-tabs-mode-setting nil)))
        ((eq expected-tab-setting 'undecided)
-        (assert (eq change-indent-tabs-mode nil))))
+        (cl-assert (eq change-indent-tabs-mode nil))))
       (if expected-offset
-          (assert (eq nil rejected) t)
-        (assert (not (eq nil rejected)) t))
-      (assert (eq expected-offset
+          (cl-assert (eq nil rejected) t)
+        (cl-assert (not (eq nil rejected)) t))
+      (cl-assert (eq expected-offset
                   best-indent-offset) t))))
 
 (defun dtrt-indent-test-rec-directory-files

--- a/dtrt-indent-test.el
+++ b/dtrt-indent-test.el
@@ -32,8 +32,6 @@
   (with-temp-buffer
     (make-local-variable 'dtrt-indent-verbosity)
     (setq dtrt-indent-verbosity 0)
-    (make-local-variable 'dtrt-indent-min-relevant-lines)
-    (setq dtrt-indent-min-relevant-lines 3)
     (insert (cdr (assoc :buffer-contents args)))
     (let* ((language-and-variable
             (cdr (dtrt-indent--search-hook-mapping
@@ -180,6 +178,16 @@ aa /*foo
  '((:buffer-contents . "")
    (:mode . c-mode)
    (:expected-tab-setting . undecided)
+   (:expected-offset . nil)))
+
+(dtrt-indent-functional-test
+ '((:buffer-contents . "\
+(let ((foo 1)
+      (bar
+       2))
+  (message \"%d %d\" foo bar))")
+   (:mode . emacs-lisp-mode)
+   (:expected-tab-setting . soft)
    (:expected-offset . nil)))
 
 (when nil ;; disabled

--- a/dtrt-indent-test.el
+++ b/dtrt-indent-test.el
@@ -71,7 +71,7 @@
         (assert (eq change-indent-tabs-mode nil))))
       (if expected-offset
           (assert (eq nil rejected) t)
-        (assert (not (eq nil rejected)) t))          
+        (assert (not (eq nil rejected)) t))
       (assert (eq expected-offset
                   best-indent-offset) t))))
 

--- a/dtrt-indent-test.el
+++ b/dtrt-indent-test.el
@@ -69,11 +69,11 @@
         (cl-assert (eq indent-tabs-mode-setting nil)))
        ((eq expected-tab-setting 'undecided)
         (cl-assert (eq change-indent-tabs-mode nil))))
-      (if expected-offset
-          (cl-assert (eq nil rejected) t)
-        (cl-assert (not (eq nil rejected)) t))
-      (cl-assert (eq expected-offset
-                  best-indent-offset) t))))
+      (if (not expected-offset)
+          (cl-assert (not (eq nil rejected)) t)
+        (cl-assert (eq nil rejected) t)
+        (cl-assert (eq expected-offset
+                       best-indent-offset) t)))))
 
 (defun dtrt-indent-test-rec-directory-files
   (directory filename-pattern function)

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -858,6 +858,8 @@ merged with offset %s (%.2f%% deviation, limit %.2f%%)"
                   (nth 1 best-guess)
                 0))
              (total-lines (nth 1 histogram-and-total-lines))
+             (enough-relevant-lines
+              (>= total-lines dtrt-indent-min-relevant-lines))
              (hard-tab-percentage (if (> total-lines 0)
                                       (/ (float (nth 2 histogram-and-total-lines))
                                          total-lines)
@@ -876,10 +878,13 @@ merged with offset %s (%.2f%% deviation, limit %.2f%%)"
                   dtrt-indent-min-quality)
                (format "best guess below minimum quality (%f < %f)"
                        (* 100.0 (nth 1 best-guess))
-                       dtrt-indent-min-quality)))))
+                       dtrt-indent-min-quality))
+              ((not enough-relevant-lines)
+               (format "not enough relevant lines (%d required)"
+                       dtrt-indent-min-relevant-lines)))))
 
         (cond
-         (rejected)
+         ((not enough-relevant-lines))
          ((or (= 0 hard-tab-percentage)
               (>= (/ soft-tab-percentage
                      hard-tab-percentage)


### PR DESCRIPTION
If a guessed offset is rejected then the tab-setting won't be applied either. This is a regression which was introduced in beb7683 (Do not change anything when analyze is rejected, 2015-04-12).

I'm affected by this issues particular in Lisp modes. Sometimes the offset cannot be guessed and because of this the tab-setting is also not applied.

I fixed this issue by using the custom option `dtrt-indent-min-relevant-lines` which exists since the very beginning of this project but was actually never used in the analysis.