### PR TITLE
Add groovy-mode and yaml-mode

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -360,6 +360,8 @@ quote, for example.")
     (vhdl-mode       default       vhdl-basic-offset) ; VHDL
     (groovy-mode     c/c++/java    (groovy-indent-offset
                                     tab-width))          ; Groovy
+    (yaml-mode       default       (yaml-indent-offset
+                                    tab-width))          ; YAML
 
     ;; Modes that use SMIE if available
     (sh-mode         default       sh-basic-offset)      ; Shell Script

--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -358,6 +358,8 @@ quote, for example.")
     (cmake-mode      cmake         cmake-tab-width)       ; CMake
     (xquery-mode     sgml          xquery-mode-indent-width) ; XQuery
     (vhdl-mode       default       vhdl-basic-offset) ; VHDL
+    (groovy-mode     c/c++/java    (groovy-indent-offset
+                                    tab-width))          ; Groovy
 
     ;; Modes that use SMIE if available
     (sh-mode         default       sh-basic-offset)      ; Shell Script


### PR DESCRIPTION
Some modes rely on tab-width for their indentation, e.g. groovy-mode and yaml-mode. I think this seems like a good default or do you see any issues with this?

Edit:
As suggested in your comment I updated the PR to explicitly add these two modes. I'll keep adding more if I run into others misbehaving.