### PR TITLE
Add bash-ts-mode to dtrt-indent-hook-mapping-list

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -373,6 +373,7 @@ quote, for example.")
 
     ;; Modes that use SMIE if available
     (sh-mode         default       sh-basic-offset)      ; Shell Script
+    (bash-ts-mode    default       sh-basic-offset)      ; Shell Script
     (ruby-mode       ruby          ruby-indent-level)    ; Ruby
     (enh-ruby-mode   ruby          enh-ruby-indent-level); Ruby
     (crystal-mode    ruby          crystal-indent-level) ; Crystal (Ruby)


### PR DESCRIPTION
This pull request adds `bash-ts-mode` to `dtrt-indent-hook-mapping-list` to support Tree-sitter-based indentation for Bash scripts.