### PR TITLE
Fix Issue 93 : compilation warning

### DIFF
--- a/dtrt-indent.el
+++ b/dtrt-indent.el
@@ -210,7 +210,7 @@ adjusted transparently."
 ;;;###autoload
 (define-globalized-minor-mode dtrt-indent-global-mode dtrt-indent-mode
   (lambda () (dtrt-indent-mode 1))
-  :predicate t '(prog-mode text-mode)
+  :predicate '(prog-mode text-mode)
   :group 'dtrt-indent)
 
 (defvar dtrt-indent-language-syntax-table


### PR DESCRIPTION
This fixes https://github.com/jscheid/dtrt-indent/issues/93

The generated defcustom and define-minor-modes now both get the :group tab to drdt-indent as they should.